### PR TITLE
Fix sizing and z-index issues with project navigator

### DIFF
--- a/assets/stylesheets/keyboard_shortcuts.css
+++ b/assets/stylesheets/keyboard_shortcuts.css
@@ -32,7 +32,7 @@
 
 #dialog-body {
   padding: 5px 15px;
-  overflow: scroll;
+  overflow: visible;
 }
 
 #dialog h3 {
@@ -65,6 +65,7 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+  z-index: 1001;
 }
 
 #dialog ul.ks-list li {

--- a/assets/stylesheets/keyboard_shortcuts.css
+++ b/assets/stylesheets/keyboard_shortcuts.css
@@ -65,7 +65,6 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
-  z-index: 1001;
 }
 
 #dialog ul.ks-list li {
@@ -80,4 +79,8 @@
 
 #dialog ul.ks-list li a.current {
   color: #000;
+}
+
+.ui-autocomplete {
+  z-index: 1001;
 }

--- a/assets/stylesheets/keyboard_shortcuts.css
+++ b/assets/stylesheets/keyboard_shortcuts.css
@@ -84,3 +84,7 @@
 .ui-autocomplete {
   z-index: 1001;
 }
+
+.ui-autocomplete-input {
+  width: 90%;
+}


### PR DESCRIPTION
In Firefox 65.0.2, the options in the project navigator appear behind the navigator modal itself. 

![image](https://user-images.githubusercontent.com/38678140/54074511-1b5f4480-4261-11e9-9efd-a95eec591732.png)

This PR fixes this and also makes it so the navigator modal stops overflowing into itself.

The updated version looks like this:
![image](https://user-images.githubusercontent.com/38678140/54074553-bf48f000-4261-11e9-90a7-0f63c4b3dc51.png)
